### PR TITLE
adding test kitchen (debian & centos) & basic smoke tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ Gemfile.lock
 bin/*
 .bundle/*
 
+# Test Kitchen
+.kitchen
+.kitchen.local.yml

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,24 @@
+---
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_zero
+  #require_chef_omnibus: 13.5.3
+
+verifier:
+  name: inspec
+
+platforms:
+  #  - name: ubuntu-16.04 # bento image wonky as of 18.02.04
+  - name: debian-9
+  - name: centos-7
+
+suites:
+  - name: default
+    run_list:
+      - recipe[chruby_install::default]
+    verifier:
+      inspec_tests:
+        - test/smoke/default
+    attributes:

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,3 @@
-site :opscode
+source 'https://supermarket.chef.io'
 
 metadata

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ian@ichilton.co.uk'
 license          'All rights reserved'
 description      'Install chruby'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.4'
+version          '0.1.4a'
 
 supports 'ubuntu'
 supports 'debian'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ian@ichilton.co.uk'
 license          'All rights reserved'
 description      'Install chruby'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.4a'
+version          '0.1.4'
 
 supports 'ubuntu'
 supports 'debian'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ian@ichilton.co.uk'
 license          'All rights reserved'
 description      'Install chruby'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.3'
+version          '0.1.4'
 
 supports 'ubuntu'
 supports 'debian'

--- a/test/smoke/default/default.rb
+++ b/test/smoke/default/default.rb
@@ -1,0 +1,10 @@
+
+describe file('/etc/profile.d/chruby.sh') do
+  it { should exist }
+  its('mode') { should cmp '00644' }
+end
+
+describe file('/usr/local/share/chruby/chruby.sh') do
+  it { should exist }
+  its('mode') { should cmp '0644' }
+end


### PR DESCRIPTION
Taking @RavWar PR for chef13 fix and added basic test kitchen for debian & centos along with very simple smoke tests.

This allows a basic `kitchen converge && kitchen verify` to verify things are working correctly in latest chef-client 13.7.16 (they do).

Signed-off-by: Dayne Broderson <broderson@gmail.com>